### PR TITLE
feat(wasm): async compile + call JS func from Rust

### DIFF
--- a/flow-typed/rollupPluginRustDef.js
+++ b/flow-typed/rollupPluginRustDef.js
@@ -1,7 +1,13 @@
 declare type Options = {
   target: string, // use by rust-native-wasm-loader
   release: boolean, // use by rust-native-wasm-loader
-  export: 'buffer' | 'instance' | 'module' | 'promise',
+  export:
+    | 'buffer'
+    | 'instance'
+    | 'module'
+    | 'async'
+    | 'async-instance'
+    | 'async-module',
   include: string[] | string, // rollup recommend to add this
   exclude: string[] | string // rollup recommend to add this
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,13 @@
 interface Options {
   target: string; // use by rust-native-wasm-loader
   release: boolean; // use by rust-native-wasm-loader
-  export: "buffer" | "instance" | "module" | "promise";
+  export:
+    | "buffer"
+    | "instance"
+    | "module"
+    | "async"
+    | "async-instance"
+    | "async-module";
   include: string[] | string; // rollup recommend to add this
   exclude: string[] | string; // rollup recommend to add this
 }

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,17 @@ export default function(options: $Shape<Options> = {}) {
 
   return {
     name: 'rust',
+    options(opts: any) {
+      let external: string[] | ((id: string) => boolean);
+
+      if (typeof opts.external === 'function')
+        external = id => opts.external(id) || id.includes('buffer');
+
+      if (Array.isArray(opts.external))
+        external = Array.from(new Set(opts.external.concat('buffer')));
+
+      return Object.assign({}, opts, { external });
+    },
     async transform(code: string, id: string) {
       if (!extension.test(id)) return;
       if (!filter(id)) return;
@@ -39,7 +50,7 @@ export default function(options: $Shape<Options> = {}) {
             return wrap(wasmCode).asWebAssembly.Instance;
           case 'module':
             return wrap(wasmCode).asWebAssembly.Module;
-          case 'promise' || 'async':
+          case 'async':
             return wrap(wasmCode).promiseWebAssembly.Both;
           case 'async-instance':
             return wrap(wasmCode).promiseWebAssembly.Instance;

--- a/src/main.js
+++ b/src/main.js
@@ -39,8 +39,12 @@ export default function(options: $Shape<Options> = {}) {
             return wrap(wasmCode).asWebAssembly.Instance;
           case 'module':
             return wrap(wasmCode).asWebAssembly.Module;
-          case 'promise':
-            return wrap(wasmCode).promiseWebAssembly;
+          case 'promise' || 'async':
+            return wrap(wasmCode).promiseWebAssembly.Both;
+          case 'async-instance':
+            return wrap(wasmCode).promiseWebAssembly.Instance;
+          case 'async-module':
+            return wrap(wasmCode).promiseWebAssembly.Module;
         }
       } else
         this.error(`only support wasm related target compile

--- a/src/options.js
+++ b/src/options.js
@@ -3,7 +3,7 @@
 export default ({
   target: 'wasm32-unknown-unknown',
   release: true,
-  export: 'promise',
+  export: 'async',
   include: ['**/*.rs'],
   exclude: ['node_modules/**', 'target/**']
 }: Options);

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -28,18 +28,18 @@ export default function(buffer: Buffer) {
     promiseWebAssembly: {
       Module:
         polyfill +
-        `module.exports = () => WebAssembly.compile(
+        `export default () => WebAssembly.compile(
           Buffer.from([${data}])
         )`,
       Instance:
         polyfill +
-        `module.exports = importObject => WebAssembly.instantiate(
+        `export default importObject => WebAssembly.instantiate(
           new WebAssembly.Module(Buffer.from([${data}])),
           importObject
         )`,
       Both:
         polyfill +
-        `module.exports = importObject => WebAssembly.instantiate(
+        `export default importObject => WebAssembly.instantiate(
             Buffer.from([${data}]), importObject
         )`
     }

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -15,20 +15,33 @@ export default function(buffer: Buffer) {
       Module:
         polyfill +
         `export default new WebAssembly.Module(
-        Buffer.from([${data}])
-      )`,
+          Buffer.from([${data}])
+        )`,
       Instance:
         polyfill +
         `export default new WebAssembly.Instance(
-        new WebAssembly.Module(
-          Buffer.from([${data}])
-        )
-      )`
+          new WebAssembly.Module(
+            Buffer.from([${data}])
+          )
+        )`
     },
-    promiseWebAssembly:
-      polyfill +
-      `export default WebAssembly.instantiate(
-      Buffer.from([${data}])
-    )`
+    promiseWebAssembly: {
+      Module:
+        polyfill +
+        `module.exports = () => WebAssembly.compile(
+          Buffer.from([${data}])
+        )`,
+      Instance:
+        polyfill +
+        `module.exports = importObject => WebAssembly.instantiate(
+          new WebAssembly.Module(Buffer.from([${data}])),
+          importObject
+        )`,
+      Both:
+        polyfill +
+        `module.exports = importObject => WebAssembly.instantiate(
+            Buffer.from([${data}]), importObject
+        )`
+    }
   };
 }

--- a/test/export.spec.js
+++ b/test/export.spec.js
@@ -52,21 +52,4 @@ describe('test export option', () => {
     expect(wasmInstance).toBeInstanceOf(WebAssembly.Instance);
     expect(wasmInstance.exports.add(1, 2)).toBe(3); // can be used directly, not suitable for big size wasm
   });
-
-  test('export of WebAssembly.instantiate', async () => {
-    const bundle = await rollup({
-      input,
-      plugins: [rust({ export: 'promise' })]
-    });
-
-    const compileWasm = await require(bundle);
-
-    // Usage
-    const { module, instance } = await compileWasm;
-    const { add } = instance.exports;
-
-    expect(module).toBeInstanceOf(WebAssembly.Module);
-    expect(instance).toBeInstanceOf(WebAssembly.Instance);
-    expect(add(1, 2)).toBe(3);
-  });
 });

--- a/test/fixtures/hook_function/Cargo.toml
+++ b/test/fixtures/hook_function/Cargo.toml
@@ -6,3 +6,6 @@ authors = ["Fahmi Akbar Wildana <fahmi.a.w@gmail.com>"]
 [lib]
 crate-type = ["cdylib"]
 path = "lib.rs"
+
+[profile.release]
+lto = true

--- a/test/fixtures/hook_function/Cargo.toml
+++ b/test/fixtures/hook_function/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "adder"
+version = "0.1.0"
+authors = ["Fahmi Akbar Wildana <fahmi.a.w@gmail.com>"]
+
+[lib]
+crate-type = ["cdylib"]
+path = "lib.rs"

--- a/test/fixtures/hook_function/index.js
+++ b/test/fixtures/hook_function/index.js
@@ -1,1 +1,1 @@
-export * from './lib.rs';
+export { default } from './lib.rs';

--- a/test/fixtures/hook_function/index.js
+++ b/test/fixtures/hook_function/index.js
@@ -1,0 +1,1 @@
+export * from './lib.rs';

--- a/test/fixtures/hook_function/lib.rs
+++ b/test/fixtures/hook_function/lib.rs
@@ -1,0 +1,13 @@
+#[link(wasm_import_module = "hook")]
+extern {
+    fn before(a: u8, b: u8);
+    fn after(c: u8);
+}
+
+#[no_mangle]
+pub fn add(a: u8, b: u8) -> u8 {
+    unsafe { before(a, b) };
+    let c = a + b;
+    unsafe { after(c) };
+    return c;
+}

--- a/test/fixtures/single_function/Cargo.toml
+++ b/test/fixtures/single_function/Cargo.toml
@@ -6,3 +6,6 @@ authors = ["Fahmi Akbar Wildana <fahmi.a.w@gmail.com>"]
 [lib]
 crate-type = ["cdylib"]
 path = "lib.rs"
+
+[profile.release]
+lto = true

--- a/test/fixtures/single_function/index.js
+++ b/test/fixtures/single_function/index.js
@@ -1,1 +1,1 @@
-export * from './lib.rs';
+export { default } from './lib.rs';

--- a/test/import.spec.js
+++ b/test/import.spec.js
@@ -1,0 +1,84 @@
+// @flow
+import { rollup } from 'rollup';
+import { require } from './util';
+import rust from '../src/main.js';
+
+describe('test export option for importjs', () => {
+  const input = 'test/fixtures/hook_function/index.js';
+
+  test('export of WebAssembly.compile', async () => {
+    const bundle = await rollup({
+      input,
+      plugins: [rust({ export: 'async-module' })]
+    });
+
+    const compileWasm = await require(bundle);
+
+    // Usage
+    const importObj = {
+      hook: {
+        before: jest.fn(),
+        after: jest.fn()
+      }
+    };
+    const module = await compileWasm();
+    const instance = new WebAssembly.Instance(module, importObj);
+    const { add } = instance.exports;
+
+    expect(module).toBeInstanceOf(WebAssembly.Module);
+    expect(instance).toBeInstanceOf(WebAssembly.Instance);
+    // $FlowFixMe: false alarm
+    expect(add(1, 2)).toBe(3);
+    expect(importObj.hook.before).toHaveBeenCalledWith(1, 2);
+    expect(importObj.hook.after).toHaveBeenCalledWith(3);
+  });
+
+  test('export of WebAssembly.instantiate(WebAssembly.Module)', async () => {
+    const bundle = await rollup({
+      input,
+      plugins: [rust({ export: 'async-instance' })]
+    });
+
+    const compileWasm = await require(bundle);
+
+    // Usage
+    const importObj = {
+      hook: {
+        before: jest.fn(),
+        after: jest.fn()
+      }
+    };
+    const instance = await compileWasm(importObj);
+    const { add } = instance.exports;
+
+    expect(instance).toBeInstanceOf(WebAssembly.Instance);
+    expect(add(1, 2)).toBe(3);
+    expect(importObj.hook.before).toHaveBeenCalledWith(1, 2);
+    expect(importObj.hook.after).toHaveBeenCalledWith(3);
+  });
+
+  test('export of WebAssembly.instantiate(Buffer)', async () => {
+    const bundle = await rollup({
+      input,
+      plugins: [rust({ export: 'async' })]
+    });
+
+    const compileWasm = await require(bundle);
+
+    // Usage
+    const importObj = {
+      hook: {
+        before: jest.fn(),
+        after: jest.fn()
+      }
+    };
+    const { module, instance } = await compileWasm(importObj);
+    const { add } = instance.exports;
+
+    expect(module).toBeInstanceOf(WebAssembly.Module);
+    expect(instance).toBeInstanceOf(WebAssembly.Instance);
+    expect(add(1, 2)).toBe(3);
+    expect(importObj.hook.before).toHaveBeenCalledWith(1, 2);
+    expect(importObj.hook.after).toHaveBeenCalledWith(3);
+  });
+});


### PR DESCRIPTION
This update is about how to compile/load wasm code asynchronously. Also, it adds the ability to import and call JS function from Rust (wasm) code. The async compile/load exists in case that someone needs to load big `.wasm` code without blocking the process.

<details>
<summary><sup>[FYI] just for future references</sup></summary>

> [WebAssembly.Module][] can be efficiently shared with Workers, and instantiated multiple times. Also, according to this [spec], it serves as the basis for dynamic linking. That's mean [WebAssembly.Module][] are basically just like `.dll` or `.so` file. If this true then there is also possiility to implement [hot-swapping][] 🤔.
</details>

[WebAssembly.Module]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module
[spec]: https://webassembly.org/docs/modules/
[hot-swapping]: https://github.com/dotnet/sdk/issues/1683